### PR TITLE
Feature/dimmer support

### DIFF
--- a/inovelli-status.html
+++ b/inovelli-status.html
@@ -8,7 +8,8 @@
             color: { value: 1 },
             level: { value: 10 },
             duration: { value: 30 },
-            display: { value: 1 }
+            display: { value: 1 },
+            switchtype: { value: 8 }
         },
         inputs:1,
         outputs:1,

--- a/inovelli-status.html
+++ b/inovelli-status.html
@@ -69,6 +69,11 @@
         <option value="4">Pulse</option>
       </select>
     </div>
+    <div class="form-row">
+      <label for="node-input-switchtype"><i class="icon-tag"></i> Switch type</label>
+      <input type="radio" id="node-input-switchtype" value="8" checked> On/Off</input>
+      <input type="radio" id="node-input-switchtype" value="16"> Dimmer</input>
+    </div>
   </script>
 
 <script type="text/x-red" data-help-name="inovelli-status-manager">
@@ -88,6 +93,9 @@
     
         <dt class="optional">Display Type <span class="property-type">number</span></dt>
         <dd>Determines how the status light will behave. (0 is Off, 1 is Solid, 2 is Fast Blink, 3 is Slow Blink, 4 is Pulse)</dd>
+
+        <dt class="optional">Switch Type <span class="property-type">radio</span></dt>
+        <dd>Determines which parameter to set. (8 is for on/off switches, 16 is for dimmer switches)</dd>
     </dl>
     <p>
       It is possible to override values set on this node by passing values in a payload e.g.
@@ -98,7 +106,8 @@ msg = {
     color: 1,
     duration: 10,
     display: 1,
-    level: 10
+    level: 10,
+    switchtype: 8
   }
 }
       </pre>

--- a/inovelli-status.js
+++ b/inovelli-status.js
@@ -8,6 +8,7 @@ module.exports = function(RED) {
         level,
         duration,
         display,
+        switchtype,
       } = config;
 
       this.nodeid = nodeid;
@@ -15,6 +16,7 @@ module.exports = function(RED) {
       this.level = parseInt(level, 10);
       this.duration = duration;
       this.display = parseInt(display, 10);
+      this.switchtype = switchtype;
 
       node.on('input', msg => {
           const { 
@@ -23,6 +25,7 @@ module.exports = function(RED) {
             level: presetLevel,
             duration: presetDuration,
             display: presetDisplay,
+            switchtype: presetSwitchtype,
           } = node;
           const { payload } = msg;
 
@@ -30,12 +33,13 @@ module.exports = function(RED) {
           const level = (payload.level || presetLevel) * 255;
           const duration = (payload.duration ||  presetDuration) * 65536;
           const display = (payload.display || presetDisplay) * 16777216;
+          const switchtype = (payload.switchtype || presetSwitchtype);
           const nodeId = payload.nodeId || nodeid
           const value = color + level + duration + display;
           const node_id = nodeId ? { node_id: nodeId } : {};
           const data = {
             ...node_id,
-            parameter: 8,
+            parameter: switchtype,
             size: 4,
             value
         }

--- a/test/inovelli-status.spec.js
+++ b/test/inovelli-status.spec.js
@@ -60,7 +60,8 @@ describe('inovelli-status node', function () {
           color: 1,
           duration: 10,
           display: 1,
-          level: 10
+          level: 10,
+          switchtype: 8
         }
       });
     });


### PR DESCRIPTION
I added a new property, switchtype, that sets the parameter. It is set by a new radio button group on the node UI. The options are "On/Off" and "Dimmer". On/Off sets the parameter value to 8, and Dimmer sets the value to 16. On/Off, or 8, is the default.

The only difference between the on/offs and the dimmers (besides parameter) that I know of is that dimmers have the effect option "Chase". I was lazy and did not add this option to the "Display Type" dropdown when the radio button is set to "Dimmer".

As a note, I have not tested this, as I'm at a loss as to _how_ to test it. I am running NR instead of Hassio (Home Assistant) which is running inside of docker. I don't think it's possible for me to install a node from local code with this set up.