### PR TITLE
Add display sets for on/off and dimmer

### DIFF
--- a/inovelli-status.html
+++ b/inovelli-status.html
@@ -17,6 +17,18 @@
         align: 'right',
         label: function() {
             return this.name || 'inovelli-status-manager';
+        },
+        oneditprepare: function() {
+          $('#node-input-switchtype').on('change', function() {
+            $('#node-input-display').val("0");
+            if (this.value === '8') {
+              $('[data-switch="onOff"]').show();
+              $('[data-switch="dimmer"]').hide();
+            } else {
+              $('[data-switch="onOff"]').hide();
+              $('[data-switch="dimmer"]').show();
+            }
+          });
         }
     });
 </script>
@@ -65,9 +77,13 @@
       <select name="node-input-display" id="node-input-display">
         <option value="0">Off</option>
         <option value="1">Solid</option>
-        <option value="2">Fast Blink</option>
-        <option value="3">Slow Blink</option>
-        <option value="4">Pulse</option>
+        <option data-switch="onOff" value="2">Fast Blink</option>
+        <option data-switch="onOff" value="3">Slow Blink</option>
+        <option data-switch="onOff" value="4">Pulse</option>
+        <option data-switch="dimmer" value="2">Chase</option>
+        <option data-switch="dimmer" value="3">Fast Blink</option>
+        <option data-switch="dimmer" value="4">Slow Blink</option>
+        <option data-switch="dimmer" value="5">Pulse</option>
       </select>
     </div>
     <div class="form-row">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-contrib-inovelli-status-manager",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/pdong/node-contrib-inovelli-status-manager.git"


### PR DESCRIPTION
This hopefully fixes the display types for dimmer vs on/off since "chase" was added as a notification display type for the dimmer firmware which is value 2.  I didn't want to introduce a breaking change with how this node treats upstream data so I left these values as numbers.  When the switch type changes it will reset the display type and allow users to pick the appropriate value.  