### PR TITLE
Fix issue where display input would reset when opening palette

### DIFF
--- a/inovelli-status.html
+++ b/inovelli-status.html
@@ -19,15 +19,32 @@
             return this.name || 'inovelli-status-manager';
         },
         oneditprepare: function() {
+          let previous;
+          const onOffOptions = 
+            `<option value="0">Off</option>
+            <option value="1">Solid</option>
+            <option value="2">Fast Blink</option>
+            <option value="3">Slow Blink</option>
+            <option value="4">Pulse</option>`
+
+          const dimmerOptions = 
+            `<option value="0">Off</option>
+            <option value="1">Solid</option>
+            <option value="2">Chase</option>
+            <option value="3">Fast Blink</option>
+            <option value="4">Slow Blink</option>
+            <option value="5">Pulse</option>` 
+
           $('#node-input-switchtype').on('change', function() {
-            $('#node-input-display').val("0");
+            const displayInput = $('#node-input-display');
+            if (previous) previous = "0";
+            if (!previous) previous = displayInput.val();
             if (this.value === '8') {
-              $('[data-switch="onOff"]').show();
-              $('[data-switch="dimmer"]').hide();
+              displayInput.html(onOffOptions);
             } else {
-              $('[data-switch="onOff"]').hide();
-              $('[data-switch="dimmer"]').show();
+              displayInput.html(dimmerOptions);
             }
+            displayInput.val(previous);
           });
         }
     });
@@ -75,15 +92,12 @@
     <div class="form-row">
       <label for="node-input-display"><i class="icon-tag"></i> Display Type</label>
       <select name="node-input-display" id="node-input-display">
-        <option value="0">Off</option>
-        <option value="1">Solid</option>
-        <option data-switch="onOff" value="2">Fast Blink</option>
-        <option data-switch="onOff" value="3">Slow Blink</option>
-        <option data-switch="onOff" value="4">Pulse</option>
-        <option data-switch="dimmer" value="2">Chase</option>
-        <option data-switch="dimmer" value="3">Fast Blink</option>
-        <option data-switch="dimmer" value="4">Slow Blink</option>
-        <option data-switch="dimmer" value="5">Pulse</option>
+          <option value="0">Placeholder</option>
+          <option value="1">Placeholder</option>
+          <option value="2">Placeholder</option>
+          <option value="3">Placeholder</option>
+          <option value="4">Placeholder</option>
+          <option value="5">Placeholder</option>
       </select>
     </div>
     <div class="form-row">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-contrib-inovelli-status-manager",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/pdong/node-contrib-inovelli-status-manager.git"


### PR DESCRIPTION
Fixes #6 

![fix](https://user-images.githubusercontent.com/5158502/72323211-01e71000-365d-11ea-8996-00399f7bfdfc.gif)

The onchange was firing when opening the palette for the first time.  I fixed this by setting the previous value when opening the palette and if the previous exists (value changing AFTER palette is open) then I reset the input.  This introduced another bug where hiding options isn't correct.  If you set the select value to an option that is hidden it, browsers will try to have make that the selection instead of the visible one.  Instead of doing hide/show I switched it to just insert the whole set of options so value 2 for a dimmer doesn't say "Fast Blink" when opening.  This should work now, hopefully.

I put a bunch of placeholder options in so that I can grab the value of the select before stomping on all the contents.  Kind of gross but it works.